### PR TITLE
Feat: Calibration + PSD comparison (closes #2, #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,213 @@
 # GrainSight -- 3D Particle Size & Granulometry Analyzer
 
-A web-based application for grain size estimation from RGB-D data using
-marker-based watershed segmentation, per-grain geometric measurement,
-and Rosin-Rammler PSD curve fitting.
+A web-based application for grain size estimation from RGB-D data using marker-based watershed segmentation, per-grain geometric measurement, and Rosin-Rammler PSD curve fitting. Built with Python/FastAPI on the backend and HTML5 Canvas for interactive browser-based visualization. The system generates synthetic grain beds, segments individual particles, computes 18 morphometric descriptors per grain, and fits particle size distributions with configurable models.
 
-## Features
+![Architecture](docs/svg/architecture.svg)
 
-- **Synthetic grain bed generation** with 5 distribution types: uniform,
-  normal, log-normal, bimodal, and Rosin-Rammler.
-- **Marker-based watershed segmentation** using depth gradient magnitude.
-- **18 per-grain metrics**: equivalent diameter, major/minor axes, aspect
-  ratio, circularity, depth-integrated volume, and more.
-- **PSD analysis**: cumulative curves (number and mass weighted), D-values
-  (D10/D25/D50/D75/D80/D90), Rosin-Rammler fit, and sieve simulation.
-- **Real-time web UI** with dark theme, interactive controls, PSD chart,
-  and measurement table.
-- **CSV export** of grain measurements.
+![Pipeline](docs/svg/pipeline.svg)
+
+## Frontend
+
+![Frontend](docs/png/frontend.png)
+
+---
 
 ## Quick Start
 
 ```bash
-cd "d:/_Repos/_SCIENCE/FASL_3D_GrainSize"
+# Clone and enter the project
+cd FASL_3D_GrainSize
+
+# Create and activate virtual environment
 python -m venv .venv
-source .venv/Scripts/activate    # Windows: .venv\Scripts\activate
+source .venv/Scripts/activate    # Windows Git Bash
+# source .venv/bin/activate      # Linux / macOS
+
+# Install dependencies
 pip install -r requirements.txt
+
+# Run tests
+python tests/test_generator.py
+python tests/test_segmentation.py
+python tests/test_measurement.py
+python tests/test_granulometry.py
+
+# Start the application
 python run_app.py
+
+# Open http://127.0.0.1:8010 in your browser
 ```
 
-Open http://127.0.0.1:8010 in your browser.
+---
+
+## Features
+
+- **5 synthetic PSD generators**: uniform, normal, log-normal, bimodal, and Rosin-Rammler distributions
+- **Marker-based watershed segmentation** on depth gradient magnitude with configurable thresholds
+- **18 per-grain geometric descriptors** (ISO 13322-1): equivalent diameter, major/minor axes, aspect ratio, circularity, depth-integrated volume, and more
+- **PSD curves**: number-weighted and mass-weighted cumulative distributions
+- **D-value extraction**: D10, D25, D50, D75, D80, D90 percentile diameters
+- **Rosin-Rammler distribution fitting** with least-squares optimization
+- **Sieve analysis simulation** using standard sieve series
+- **Pixel-to-mm calibration**: reference object or direct scale entry
+- **PSD comparison with ground truth** sieve data (RMSE, KS statistic, D50 error)
+- **Depth-integrated volume estimation** per grain from depth map
+- **CSV export** of grain measurements for external analysis
+- **Real-time web UI** with dark theme, interactive controls, PSD chart, and measurement table
+- **WebSocket streaming** for real-time state updates during processing
+- **REST API** with full control over generation, segmentation, and analysis parameters
+
+---
+
+## Mathematical Model
+
+### Equivalent Diameter
+
+Each grain's equivalent circular diameter is derived from its projected area:
+
+```
+d_eq = 2 * sqrt(A / pi)
+```
+
+where `A` is the segmented grain area in pixels (or calibrated units).
+
+### Rosin-Rammler Particle Size Distribution
+
+The cumulative retained fraction is modeled as:
+
+```
+R(x) = 1 - exp(-(x / x_0)^n)
+```
+
+where `x_0` is the characteristic grain size (63.2% passing) and `n` is the spread index (uniformity coefficient).
+
+### Circularity
+
+A shape descriptor measuring how close a grain outline is to a perfect circle:
+
+```
+Circularity = 4 * pi * A / P^2
+```
+
+where `A` is the grain area and `P` is the grain perimeter. A perfect circle has circularity = 1.
+
+### Aspect Ratio
+
+```
+AR = major_axis / minor_axis
+```
+
+where the axes are derived from the eigenvalues of the grain region's inertia tensor.
+
+### 3D Surface Area (Triangle Decomposition)
+
+```
+A_3D = Sum  0.5 * |e_1 x e_2|
+```
+
+Each depth-map pixel quad is split into two triangles; the cross product of edge vectors yields the true 3D area.
+
+### Depth-Integrated Volume
+
+```
+V = Sum (z(i,j) - z_base) * dx * dy
+```
+
+where `z_base` is the local background depth and `dx`, `dy` are the calibrated pixel spacings.
+
+---
+
+## Project Structure
+
+```
+FASL_3D_GrainSize/
+├── app/
+│   ├── __init__.py
+│   ├── main.py                          # FastAPI app entry point (port 8010)
+│   ├── api/
+│   │   ├── __init__.py
+│   │   └── routes.py                    # REST + WebSocket endpoints
+│   ├── simulation/
+│   │   ├── __init__.py
+│   │   ├── grain_generator.py           # Synthetic grain bed generator (5 distributions)
+│   │   ├── segmentation.py              # Marker-based watershed segmentation
+│   │   ├── measurement.py               # 18 per-grain morphometric descriptors
+│   │   └── granulometry.py              # PSD curves, D-values, Rosin-Rammler fit
+│   └── static/
+│       ├── index.html                   # Single-page application frontend
+│       ├── css/
+│       │   └── style.css                # Dark theme stylesheet
+│       └── js/
+│           ├── app.js                   # Main controller
+│           ├── renderer.js              # Canvas rendering for grain images and PSD charts
+│           └── websocket.js             # WebSocket client
+├── tests/
+│   ├── __init__.py
+│   ├── test_generator.py                # Grain bed generation tests
+│   ├── test_segmentation.py             # Watershed segmentation tests
+│   ├── test_measurement.py              # Morphometric descriptor tests
+│   └── test_granulometry.py             # PSD and Rosin-Rammler fit tests
+├── docs/
+│   ├── architecture.md                  # System design documentation
+│   ├── granulometry_theory.md           # Mathematical foundations
+│   ├── development_history.md           # Changelog
+│   ├── references.md                    # Academic references
+│   └── svg/
+│       ├── architecture.svg             # System architecture diagram
+│       └── pipeline.svg                 # Processing pipeline diagram
+├── requirements.txt                     # Python dependencies
+├── run_app.py                           # Uvicorn launcher with auto-browser
+├── build.spec                           # PyInstaller spec file
+└── Build_PyInstaller.ps1                # PowerShell build script
+```
+
+---
+
+## API Documentation
+
+### REST Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/generate` | Generate synthetic grain bed |
+| `POST` | `/api/segment` | Re-run grain segmentation |
+| `GET` | `/api/measurements` | Per-grain measurement table |
+| `GET` | `/api/psd` | PSD curve + percentiles + R-R fit |
+| `POST` | `/api/settings` | Update processing parameters |
+| `GET` | `/api/state` | Full state snapshot |
+| `GET` | `/api/export/csv` | Export measurements as CSV |
+
+### WebSocket
+
+| Path | Description |
+|------|-------------|
+| `WS /ws` | Real-time state streaming during processing |
+
+---
+
+## Port
+
+**8010** -- http://localhost:8010
+
+---
+
+## Technology Stack
+
+- **Backend**: Python 3.12+, FastAPI, Uvicorn, NumPy, SciPy, scikit-image
+- **Frontend**: Vanilla JavaScript, HTML5 Canvas, CSS3
+- **Protocol**: REST + WebSocket
+- **Packaging**: PyInstaller
+
+---
+
+## Documentation
+
+- [Architecture](docs/architecture.md) -- System design, components, data flow
+- [Granulometry Theory](docs/granulometry_theory.md) -- Mathematical foundations: PSD, Rosin-Rammler, watershed
+- [Development History](docs/development_history.md) -- Changelog and decisions
+- [References](docs/references.md) -- Academic papers and standards
+
+---
 
 ## Running Tests
 
@@ -36,7 +216,12 @@ python tests/test_generator.py
 python tests/test_segmentation.py
 python tests/test_measurement.py
 python tests/test_granulometry.py
+
+# Or run all tests
+python -m pytest tests/ -v
 ```
+
+---
 
 ## Building Standalone Executable
 
@@ -44,32 +229,16 @@ python tests/test_granulometry.py
 .\Build_PyInstaller.ps1
 ```
 
-## Technology Stack
+---
 
-- **Backend**: Python, FastAPI, Uvicorn, NumPy, SciPy, scikit-image
-- **Frontend**: Vanilla JavaScript, HTML5 Canvas, CSS3
-- **Protocol**: REST + WebSocket
-- **Packaging**: PyInstaller
+## References
 
-## Documentation
+- Rosin, P. & Rammler, E. (1933). The laws governing the fineness of powdered coal. *Journal of the Institute of Fuel*, 7:29-36.
+- Beucher, S. & Lantuejoul, C. (1979). Use of watersheds in contour detection. *International Workshop on Image Processing*.
+- ISO 13322-1:2014. Particle size analysis -- Image analysis methods.
+- Wentworth, C.K. (1922). A scale of grade and class terms for clastic sediments. *Journal of Geology*, 30(5).
 
-- [Architecture](docs/architecture.md)
-- [Granulometry Theory](docs/granulometry_theory.md)
-- [Development History](docs/development_history.md)
-- [References](docs/references.md)
-
-## API Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/generate` | Generate synthetic grain bed |
-| POST | `/api/segment` | Re-run grain segmentation |
-| GET | `/api/measurements` | Per-grain measurement table |
-| GET | `/api/psd` | PSD curve + percentiles + R-R fit |
-| POST | `/api/settings` | Update processing parameters |
-| GET | `/api/state` | Full state snapshot |
-| GET | `/api/export/csv` | Export measurements as CSV |
-| WS | `/ws` | Real-time state streaming |
+---
 
 ## License
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -18,3 +18,8 @@ router = APIRouter(prefix="/api", tags=["grainsight"])
 # - POST /api/batch         -- Batch processing of multiple images
 # - GET  /api/presets       -- Parameter preset management
 # - POST /api/report        -- Generate PDF analysis report
+#
+# Endpoints added in main.py:
+# - POST /api/calibrate     -- Pixel-to-mm calibration (reference or direct)
+# - GET  /api/calibration   -- Current calibration state
+# - POST /api/compare-psd   -- Compare estimated PSD with ground truth sieve data

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ import csv
 import io
 import json
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
@@ -38,7 +38,13 @@ from .simulation.segmentation import (
     segment_grains_depth_edges,
 )
 from .simulation.grain_measurement import measure_grains
-from .simulation.granulometry import full_psd_analysis
+from .simulation.granulometry import (
+    full_psd_analysis,
+    compare_psd,
+    generate_sieve_ground_truth,
+    compute_psd,
+)
+from .simulation.calibration import Calibration
 from .simulation.depth_features import (
     compute_depth_gradient,
     detect_grain_peaks,
@@ -65,6 +71,8 @@ app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 # Shared mutable state
 # ------------------------------------------------------------------ #
 
+calibration = Calibration()
+
 state: dict = {
     "rgb": None,              # (H, W, 3) uint8
     "depth": None,            # (H, W) float32
@@ -72,6 +80,7 @@ state: dict = {
     "true_diameters": None,   # list[float]
     "measurements": None,     # list[dict]
     "psd": None,              # dict
+    "comparison": None,       # dict -- PSD comparison metrics
     "settings": {
         "bed_type": "lognormal",
         "width": 256,
@@ -125,6 +134,24 @@ class SettingsUpdate(BaseModel):
     psd_method: Optional[str] = None
 
 
+class CalibrateRequest(BaseModel):
+    """Request body for calibration.
+
+    Either provide (point_a, point_b, known_length_mm) for reference-object
+    calibration, or provide pixel_size_mm for direct pixel-size entry.
+    """
+    point_a: Optional[List[float]] = None
+    point_b: Optional[List[float]] = None
+    known_length_mm: Optional[float] = None
+    pixel_size_mm: Optional[float] = None
+
+
+class ComparePsdRequest(BaseModel):
+    """Request body for PSD comparison with ground truth sieve data."""
+    true_sizes: List[float] = Field(..., description="Sieve sizes (mm)")
+    true_passing: List[float] = Field(..., description="Cumulative passing (%)")
+
+
 # ------------------------------------------------------------------ #
 # Helpers
 # ------------------------------------------------------------------ #
@@ -170,8 +197,17 @@ def _run_measurements():
         return
 
     s = state["settings"]
+
+    # Use calibration if calibrated; otherwise fall back to settings pixel_size
+    effective_pixel_size = (
+        calibration.pixel_size_mm if calibration.calibrated
+        else s["pixel_size"]
+    )
+
     measurements = measure_grains(
-        state["labels"], state["depth"], pixel_size=s["pixel_size"],
+        state["labels"], state["depth"],
+        pixel_size=effective_pixel_size,
+        calibration=calibration if calibration.calibrated else None,
     )
     state["measurements"] = measurements
 
@@ -200,6 +236,8 @@ def _build_state_payload() -> dict:
         "true_diameters": state["true_diameters"],
         "measurements": state["measurements"],
         "psd": state["psd"],
+        "comparison": state["comparison"],
+        "calibration": calibration.get_state(),
         "settings": state["settings"],
     }
     return payload
@@ -336,6 +374,84 @@ async def api_export_csv():
         media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=grain_measurements.csv"},
     )
+
+
+# ------------------------------------------------------------------ #
+# Calibration endpoints
+# ------------------------------------------------------------------ #
+
+@app.post("/api/calibrate")
+async def api_calibrate(req: CalibrateRequest):
+    """Calibrate pixel-to-mm conversion.
+
+    Supports two modes:
+    - Reference object: provide point_a, point_b, known_length_mm
+    - Direct pixel size: provide pixel_size_mm
+    """
+    if req.pixel_size_mm is not None:
+        ok = calibration.calibrate_from_pixel_size(req.pixel_size_mm)
+    elif (req.point_a is not None and req.point_b is not None
+          and req.known_length_mm is not None):
+        ok = calibration.calibrate_from_reference(
+            req.point_a, req.point_b, req.known_length_mm,
+        )
+    else:
+        return {"status": "error",
+                "detail": "Provide pixel_size_mm or (point_a, point_b, known_length_mm)"}
+
+    if not ok:
+        return {"status": "error", "detail": "Calibration failed (zero-length reference)"}
+
+    # Also sync the settings pixel_size to calibration value
+    state["settings"]["pixel_size"] = calibration.pixel_size_mm
+
+    # Re-run measurements with new calibration
+    if state["depth"] is not None and state["labels"] is not None:
+        _run_measurements()
+        payload = _build_state_payload()
+        await _broadcast({"type": "state", "data": payload})
+
+    return {"status": "ok", "calibration": calibration.get_state()}
+
+
+@app.get("/api/calibration")
+async def api_calibration():
+    """Return current calibration state."""
+    return calibration.get_state()
+
+
+# ------------------------------------------------------------------ #
+# PSD comparison endpoint
+# ------------------------------------------------------------------ #
+
+@app.post("/api/compare-psd")
+async def api_compare_psd(req: ComparePsdRequest):
+    """Compare estimated PSD against ground truth sieve data.
+
+    Returns RMSE, KS statistic, D50 comparison metrics, and the
+    interpolated ground truth curve for overlay rendering.
+    """
+    if state["psd"] is None:
+        return {"status": "error", "detail": "No PSD data available. Generate a grain bed first."}
+
+    estimated_sizes = state["psd"]["sizes"]
+    estimated_passing = state["psd"]["passing"]
+
+    metrics = compare_psd(
+        estimated_sizes, estimated_passing,
+        req.true_sizes, req.true_passing,
+    )
+
+    state["comparison"] = {
+        "metrics": metrics,
+        "true_sizes": req.true_sizes,
+        "true_passing": req.true_passing,
+    }
+
+    payload = _build_state_payload()
+    await _broadcast({"type": "state", "data": payload})
+
+    return {"status": "ok", "comparison": state["comparison"]}
 
 
 # ------------------------------------------------------------------ #

--- a/app/simulation/calibration.py
+++ b/app/simulation/calibration.py
@@ -1,0 +1,61 @@
+"""
+Image calibration: pixel-to-physical-unit conversion.
+
+Calibration is essential for accurate grain size measurement.
+Without it, measurements are in pixels; with it, in millimeters.
+
+Two calibration methods:
+1. Reference object: user places an object of known size, clicks
+   two points to define the reference length.
+2. Known pixel size: user enters the pixel pitch directly
+   (e.g., from camera/sensor datasheet).
+"""
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class Calibration:
+    """Stores the pixel-to-physical calibration."""
+    pixel_size_mm: float = 1.0  # mm per pixel
+    reference_length_mm: float = 0.0
+    reference_length_px: float = 0.0
+    calibrated: bool = False
+
+    def calibrate_from_reference(self, point_a, point_b, known_length_mm):
+        """Calibrate using two points of known physical distance.
+
+        pixel_size = known_length_mm / distance_in_pixels
+        """
+        dx = point_b[0] - point_a[0]
+        dy = point_b[1] - point_a[1]
+        dist_px = np.sqrt(dx**2 + dy**2)
+        if dist_px < 1e-6:
+            return False
+        self.pixel_size_mm = known_length_mm / dist_px
+        self.reference_length_mm = known_length_mm
+        self.reference_length_px = dist_px
+        self.calibrated = True
+        return True
+
+    def calibrate_from_pixel_size(self, pixel_size_mm):
+        """Set pixel size directly from sensor specifications."""
+        self.pixel_size_mm = pixel_size_mm
+        self.calibrated = True
+        return True
+
+    def px_to_mm(self, value_px):
+        """Convert pixel measurement to millimeters."""
+        return value_px * self.pixel_size_mm
+
+    def area_px_to_mm2(self, area_px):
+        """Convert pixel area to mm squared."""
+        return area_px * self.pixel_size_mm**2
+
+    def get_state(self):
+        return {
+            'pixel_size_mm': self.pixel_size_mm,
+            'calibrated': self.calibrated,
+            'reference_length_mm': self.reference_length_mm,
+            'reference_length_px': self.reference_length_px,
+        }

--- a/app/simulation/grain_measurement.py
+++ b/app/simulation/grain_measurement.py
@@ -50,16 +50,19 @@ References
 from __future__ import annotations
 
 import math
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 from scipy import ndimage
+
+from .calibration import Calibration
 
 
 def measure_grains(
     labels: np.ndarray,
     depth: np.ndarray,
     pixel_size: float = 1.0,
+    calibration: Optional[Calibration] = None,
 ) -> List[Dict]:
     """Measure geometric properties of each segmented grain.
 
@@ -72,6 +75,9 @@ def measure_grains(
     pixel_size : float
         Physical size of one pixel (e.g. mm/px).  All length and area
         measurements are scaled by this factor.
+    calibration : Calibration, optional
+        If provided and calibrated, overrides ``pixel_size`` with the
+        calibration's pixel_size_mm value.
 
     Returns
     -------
@@ -85,6 +91,10 @@ def measure_grains(
         ``mean_depth``, ``depth_range``, ``volume``,
         ``centroid_x``, ``centroid_y``.
     """
+    # Use calibration pixel_size if available and calibrated
+    if calibration is not None and calibration.calibrated:
+        pixel_size = calibration.pixel_size_mm
+
     unique_labels = np.unique(labels)
     unique_labels = unique_labels[unique_labels > 0]
 

--- a/app/simulation/granulometry.py
+++ b/app/simulation/granulometry.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
+from scipy.interpolate import interp1d
 from scipy.optimize import curve_fit
 
 
@@ -352,4 +353,112 @@ def full_psd_analysis(
             "bin_edges": bin_edges.tolist(),
             "counts": counts.tolist(),
         },
+    }
+
+
+# ------------------------------------------------------------------ #
+# PSD comparison with ground truth sieve data
+# ------------------------------------------------------------------ #
+
+def compare_psd(
+    estimated_sizes: Sequence[float],
+    estimated_passing: Sequence[float],
+    true_sizes: Sequence[float],
+    true_passing: Sequence[float],
+) -> Dict[str, float]:
+    """Compare estimated PSD against ground truth sieve data.
+
+    Metrics:
+    - RMSE: Root Mean Square Error of cumulative passing
+    - KS test: Kolmogorov-Smirnov statistic (max difference)
+    - D50 error: |D50_estimated - D50_true| / D50_true
+
+    Parameters
+    ----------
+    estimated_sizes, estimated_passing : sequence of float
+        Estimated cumulative PSD curve.
+    true_sizes, true_passing : sequence of float
+        Ground truth (sieve analysis) cumulative PSD curve.
+
+    Returns
+    -------
+    metrics : dict
+        ``rmse``, ``ks_statistic``, ``estimated_d50``, ``true_d50``,
+        ``d50_relative_error``.
+    """
+    est_s = np.asarray(estimated_sizes, dtype=np.float64)
+    est_p = np.asarray(estimated_passing, dtype=np.float64)
+    true_s = np.asarray(true_sizes, dtype=np.float64)
+    true_p = np.asarray(true_passing, dtype=np.float64)
+
+    if len(est_s) < 2 or len(true_s) < 2:
+        return {
+            'rmse': float('nan'),
+            'ks_statistic': float('nan'),
+            'estimated_d50': float('nan'),
+            'true_d50': float('nan'),
+            'd50_relative_error': float('nan'),
+        }
+
+    # Interpolate both to common size grid
+    common_sizes = np.union1d(est_s, true_s)
+    lo = max(est_s.min(), true_s.min())
+    hi = min(est_s.max(), true_s.max())
+    common_sizes = common_sizes[(common_sizes >= lo) & (common_sizes <= hi)]
+
+    if len(common_sizes) < 2:
+        common_sizes = np.linspace(lo, hi, 50)
+
+    est_interp = interp1d(est_s, est_p,
+                          bounds_error=False, fill_value=(0, 100))
+    true_interp = interp1d(true_s, true_p,
+                           bounds_error=False, fill_value=(0, 100))
+
+    est_vals = est_interp(common_sizes)
+    true_vals = true_interp(common_sizes)
+
+    rmse = float(np.sqrt(np.mean((est_vals - true_vals) ** 2)))
+    ks_stat = float(np.max(np.abs(est_vals - true_vals)))
+
+    # D50 comparison
+    est_d50 = float(np.interp(50, est_p, est_s))
+    true_d50 = float(np.interp(50, true_p, true_s))
+    d50_error = abs(est_d50 - true_d50) / (true_d50 + 1e-10)
+
+    return {
+        'rmse': round(rmse, 4),
+        'ks_statistic': round(ks_stat, 4),
+        'estimated_d50': round(est_d50, 4),
+        'true_d50': round(true_d50, 4),
+        'd50_relative_error': round(float(d50_error), 4),
+    }
+
+
+def generate_sieve_ground_truth(
+    true_diameters: Sequence[float],
+    sieve_sizes: Optional[Sequence[float]] = None,
+) -> Dict:
+    """Generate the ground truth sieve analysis from known diameters.
+
+    Used for validation against the segmentation-based estimation.
+
+    Parameters
+    ----------
+    true_diameters : sequence of float
+        Known grain diameters (ground truth).
+    sieve_sizes : sequence of float or None
+        Custom sieve sizes.  If *None*, standard series is used.
+
+    Returns
+    -------
+    result : dict
+        ``sieve_sizes``, ``cum_passing`` (percentage), ``retained``.
+    """
+    sv_sizes, retained, cum_passing = compute_sieve_analysis(
+        true_diameters, sieve_sizes=sieve_sizes,
+    )
+    return {
+        "sieve_sizes": sv_sizes.tolist(),
+        "cum_passing": cum_passing.tolist(),
+        "retained": retained.tolist(),
     }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -177,6 +177,49 @@
             </div>
         </div>
 
+        <!-- Calibration -->
+        <div class="ctrl-section">
+            <h3>Calibration</h3>
+            <div class="ctrl-row">
+                <label data-tooltip="Status: calibrated or uncalibrated">Status</label>
+                <span class="value" id="calib-status">Uncalibrated</span>
+            </div>
+            <div class="ctrl-row">
+                <label data-tooltip="Direct pixel size in mm/px">Pixel size (mm/px)</label>
+                <input type="number" id="ctrl-calib-pixel-size" value="1.0" min="0.001" max="1000" step="0.001">
+            </div>
+            <button class="btn btn-full" id="btn-calib-pixel-size">Set Pixel Size</button>
+            <hr style="border-color:#30363d;margin:6px 0">
+            <div class="ctrl-row">
+                <label data-tooltip="Reference point A (x, y)">Point A (x,y)</label>
+                <input type="text" id="ctrl-calib-point-a" value="0,0" placeholder="x,y">
+            </div>
+            <div class="ctrl-row">
+                <label data-tooltip="Reference point B (x, y)">Point B (x,y)</label>
+                <input type="text" id="ctrl-calib-point-b" value="100,0" placeholder="x,y">
+            </div>
+            <div class="ctrl-row">
+                <label data-tooltip="Known physical distance (mm)">Known length (mm)</label>
+                <input type="number" id="ctrl-calib-length" value="10.0" min="0.001" max="10000" step="0.01">
+            </div>
+            <button class="btn btn-full" id="btn-calib-reference">Set Reference</button>
+        </div>
+
+        <!-- Sieve data comparison -->
+        <div class="ctrl-section">
+            <h3>Compare with Sieve Data</h3>
+            <div class="ctrl-row">
+                <label data-tooltip="Comma-separated sieve sizes in mm">Sieve sizes (mm)</label>
+                <input type="text" id="ctrl-sieve-sizes" placeholder="0.075,0.15,0.3,0.6,1.18">
+            </div>
+            <div class="ctrl-row">
+                <label data-tooltip="Comma-separated cumulative passing %">Passing (%)</label>
+                <input type="text" id="ctrl-sieve-passing" placeholder="5,15,35,65,90">
+            </div>
+            <button class="btn btn-full" id="btn-compare-psd">Import Sieve Data</button>
+            <div id="comparison-results" style="margin-top:6px;font-size:11px;color:#8b949e;"></div>
+        </div>
+
     </div>
 </div>
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -64,8 +64,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (data.depth)  Renderer2D.drawDepth("canvas-depth", data.depth);
         if (data.labels) Renderer2D.drawLabels("canvas-labels", data.labels);
 
-        // Draw PSD chart
-        Renderer2D.drawPSD("canvas-psd", data.psd);
+        // Draw PSD chart (with optional ground truth overlay)
+        Renderer2D.drawPSD("canvas-psd", data.psd, data.comparison);
 
         // Update metrics bar
         mGrains.textContent = data.num_grains || "--";
@@ -87,6 +87,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Update grain table
         updateTable(data.measurements);
+
+        // Update calibration status
+        if (data.calibration) updateCalibStatus(data.calibration);
+
+        // Update comparison results
+        if (data.comparison && data.comparison.metrics) {
+            showComparisonResults(data.comparison.metrics);
+        }
     }
 
     function updateTable(measurements) {
@@ -203,6 +211,94 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Also re-segment when PSD method or pixel size change
     ctrlPsdMethod.addEventListener("change", apiResegment);
+
+    // -------------------------------------------------------------- //
+    // Calibration controls
+    // -------------------------------------------------------------- //
+    const btnCalibPixelSize = document.getElementById("btn-calib-pixel-size");
+    const btnCalibReference = document.getElementById("btn-calib-reference");
+    const calibStatus       = document.getElementById("calib-status");
+
+    if (btnCalibPixelSize) {
+        btnCalibPixelSize.addEventListener("click", async () => {
+            const px = parseFloat(document.getElementById("ctrl-calib-pixel-size").value);
+            if (isNaN(px) || px <= 0) return;
+            try {
+                const resp = await fetch("/api/calibrate", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ pixel_size_mm: px }),
+                });
+                const data = await resp.json();
+                if (data.calibration) updateCalibStatus(data.calibration);
+            } catch (e) { console.error("Calibration error:", e); }
+        });
+    }
+
+    if (btnCalibReference) {
+        btnCalibReference.addEventListener("click", async () => {
+            const parsePoint = (s) => s.split(",").map(Number);
+            const pa = parsePoint(document.getElementById("ctrl-calib-point-a").value);
+            const pb = parsePoint(document.getElementById("ctrl-calib-point-b").value);
+            const len = parseFloat(document.getElementById("ctrl-calib-length").value);
+            if (pa.length !== 2 || pb.length !== 2 || isNaN(len)) return;
+            try {
+                const resp = await fetch("/api/calibrate", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ point_a: pa, point_b: pb, known_length_mm: len }),
+                });
+                const data = await resp.json();
+                if (data.calibration) updateCalibStatus(data.calibration);
+            } catch (e) { console.error("Calibration error:", e); }
+        });
+    }
+
+    function updateCalibStatus(cal) {
+        if (calibStatus) {
+            calibStatus.textContent = cal.calibrated
+                ? `Calibrated (${cal.pixel_size_mm.toFixed(4)} mm/px)`
+                : "Uncalibrated";
+        }
+    }
+
+    // -------------------------------------------------------------- //
+    // Sieve data comparison
+    // -------------------------------------------------------------- //
+    const btnComparePsd   = document.getElementById("btn-compare-psd");
+    const comparisonDiv   = document.getElementById("comparison-results");
+
+    if (btnComparePsd) {
+        btnComparePsd.addEventListener("click", async () => {
+            const sizesStr  = document.getElementById("ctrl-sieve-sizes").value;
+            const passStr   = document.getElementById("ctrl-sieve-passing").value;
+            if (!sizesStr || !passStr) return;
+            const trueSizes   = sizesStr.split(",").map(Number);
+            const truePassing = passStr.split(",").map(Number);
+            if (trueSizes.some(isNaN) || truePassing.some(isNaN)) return;
+            try {
+                const resp = await fetch("/api/compare-psd", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ true_sizes: trueSizes, true_passing: truePassing }),
+                });
+                const data = await resp.json();
+                if (data.comparison && data.comparison.metrics) {
+                    showComparisonResults(data.comparison.metrics);
+                }
+            } catch (e) { console.error("Compare PSD error:", e); }
+        });
+    }
+
+    function showComparisonResults(m) {
+        if (!comparisonDiv) return;
+        comparisonDiv.innerHTML = `
+            RMSE: ${m.rmse.toFixed(2)}%<br>
+            KS stat: ${m.ks_statistic.toFixed(2)}%<br>
+            D50 est: ${m.estimated_d50.toFixed(2)} | true: ${m.true_d50.toFixed(2)}<br>
+            D50 rel. error: ${(m.d50_relative_error * 100).toFixed(1)}%
+        `;
+    }
 
     // Handle window resize
     window.addEventListener("resize", () => {

--- a/app/static/js/renderer2d.js
+++ b/app/static/js/renderer2d.js
@@ -227,7 +227,7 @@ const Renderer2D = (() => {
      * @param {string} canvasId
      * @param {object} psd - PSD data from the backend.
      */
-    function drawPSD(canvasId, psd) {
+    function drawPSD(canvasId, psd, comparison) {
         const canvas = document.getElementById(canvasId);
         if (!canvas) return;
         _fitCanvas(canvas);
@@ -327,6 +327,29 @@ const Renderer2D = (() => {
                 ctx.textAlign = "center";
                 ctx.fillText(`${key}=${val.toFixed(1)}`, x, pad.top - 4);
             }
+        }
+
+        // Ground truth overlay (sieve data comparison)
+        if (comparison && comparison.true_sizes && comparison.true_passing) {
+            const ts = comparison.true_sizes;
+            const tp = comparison.true_passing;
+            ctx.strokeStyle = "#f85149";
+            ctx.lineWidth = 2;
+            ctx.setLineDash([6, 3]);
+            ctx.beginPath();
+            for (let i = 0; i < ts.length; i++) {
+                const x = xScale(ts[i]);
+                const y = yScale(tp[i]);
+                if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+            }
+            ctx.stroke();
+            ctx.setLineDash([]);
+
+            // Legend label for ground truth
+            ctx.fillStyle = "#f85149";
+            ctx.font = "10px monospace";
+            ctx.textAlign = "left";
+            ctx.fillText("-- Ground truth (sieve)", pad.left + 6, pad.top + 14);
         }
 
         // Axes

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the calibration module.
+
+Tests cover:
+- Default state (uncalibrated)
+- Calibration from reference points
+- Calibration from direct pixel size
+- Pixel-to-mm and area conversions
+- Edge cases (zero-length reference)
+- Integration with grain measurement
+"""
+
+import sys
+import os
+import math
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.simulation.calibration import Calibration
+from app.simulation.grain_generator import generate_grain_bed
+from app.simulation.segmentation import segment_grains_watershed
+from app.simulation.grain_measurement import measure_grains
+
+
+class TestCalibration(unittest.TestCase):
+    """Tests for Calibration dataclass."""
+
+    def test_default_uncalibrated(self):
+        """New calibration should be uncalibrated with pixel_size=1.0."""
+        cal = Calibration()
+        self.assertFalse(cal.calibrated)
+        self.assertEqual(cal.pixel_size_mm, 1.0)
+
+    def test_calibrate_from_pixel_size(self):
+        """Direct pixel size calibration should set calibrated=True."""
+        cal = Calibration()
+        result = cal.calibrate_from_pixel_size(0.25)
+        self.assertTrue(result)
+        self.assertTrue(cal.calibrated)
+        self.assertAlmostEqual(cal.pixel_size_mm, 0.25)
+
+    def test_calibrate_from_reference(self):
+        """Reference-based calibration computes correct pixel size."""
+        cal = Calibration()
+        # 100 px horizontal distance = 10 mm  =>  0.1 mm/px
+        result = cal.calibrate_from_reference([0, 0], [100, 0], 10.0)
+        self.assertTrue(result)
+        self.assertTrue(cal.calibrated)
+        self.assertAlmostEqual(cal.pixel_size_mm, 0.1, places=6)
+        self.assertAlmostEqual(cal.reference_length_mm, 10.0)
+        self.assertAlmostEqual(cal.reference_length_px, 100.0)
+
+    def test_calibrate_from_reference_diagonal(self):
+        """Diagonal reference should compute Euclidean distance."""
+        cal = Calibration()
+        # Distance = sqrt(30^2 + 40^2) = 50 px.  Known = 25 mm => 0.5 mm/px
+        result = cal.calibrate_from_reference([10, 10], [40, 50], 25.0)
+        self.assertTrue(result)
+        self.assertAlmostEqual(cal.pixel_size_mm, 0.5, places=6)
+
+    def test_calibrate_zero_distance_fails(self):
+        """Zero-length reference should fail gracefully."""
+        cal = Calibration()
+        result = cal.calibrate_from_reference([5, 5], [5, 5], 10.0)
+        self.assertFalse(result)
+        self.assertFalse(cal.calibrated)
+
+    def test_px_to_mm(self):
+        """Pixel-to-mm conversion should use pixel_size_mm."""
+        cal = Calibration()
+        cal.calibrate_from_pixel_size(0.5)
+        self.assertAlmostEqual(cal.px_to_mm(10), 5.0)
+        self.assertAlmostEqual(cal.px_to_mm(0), 0.0)
+        self.assertAlmostEqual(cal.px_to_mm(1), 0.5)
+
+    def test_area_px_to_mm2(self):
+        """Area conversion should use pixel_size^2."""
+        cal = Calibration()
+        cal.calibrate_from_pixel_size(0.5)
+        # 100 px^2 * (0.5 mm/px)^2 = 25 mm^2
+        self.assertAlmostEqual(cal.area_px_to_mm2(100), 25.0)
+
+    def test_get_state(self):
+        """get_state should return a dict with expected keys."""
+        cal = Calibration()
+        cal.calibrate_from_pixel_size(2.0)
+        s = cal.get_state()
+        self.assertIn('pixel_size_mm', s)
+        self.assertIn('calibrated', s)
+        self.assertIn('reference_length_mm', s)
+        self.assertIn('reference_length_px', s)
+        self.assertTrue(s['calibrated'])
+        self.assertAlmostEqual(s['pixel_size_mm'], 2.0)
+
+    def test_measurement_with_calibration(self):
+        """measure_grains should use calibration pixel_size when provided."""
+        rgb, depth, _, _ = generate_grain_bed(
+            bed_type="normal", width=64, height=64, num_grains=10, seed=88,
+        )
+        labels = segment_grains_watershed(depth, rgb)
+
+        cal = Calibration()
+        cal.calibrate_from_pixel_size(0.5)
+
+        m_cal = measure_grains(labels, depth, calibration=cal)
+        m_def = measure_grains(labels, depth, pixel_size=1.0)
+
+        # With 0.5 mm/px, areas should be 0.25x the default (pixel_size=1.0)
+        if len(m_cal) > 0 and len(m_def) > 0:
+            ratio = m_cal[0]["area_mm2"] / m_def[0]["area_mm2"]
+            self.assertAlmostEqual(ratio, 0.25, places=2)
+
+    def test_calibration_overrides_pixel_size(self):
+        """When calibration is provided, pixel_size argument is ignored."""
+        rgb, depth, _, _ = generate_grain_bed(
+            bed_type="normal", width=64, height=64, num_grains=10, seed=88,
+        )
+        labels = segment_grains_watershed(depth, rgb)
+
+        cal = Calibration()
+        cal.calibrate_from_pixel_size(2.0)
+
+        # pixel_size=1.0 should be overridden by calibration pixel_size=2.0
+        m1 = measure_grains(labels, depth, pixel_size=1.0, calibration=cal)
+        m2 = measure_grains(labels, depth, pixel_size=999.0, calibration=cal)
+
+        if len(m1) > 0 and len(m2) > 0:
+            self.assertAlmostEqual(m1[0]["area_mm2"], m2[0]["area_mm2"], places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_psd_comparison.py
+++ b/tests/test_psd_comparison.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for PSD comparison functions.
+
+Tests cover:
+- compare_psd: RMSE, KS statistic, D50 error metrics
+- generate_sieve_ground_truth: output structure and consistency
+- Perfect match case (zero error)
+- Known offset case
+- Edge cases (short arrays, identical curves)
+"""
+
+import sys
+import os
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.simulation.granulometry import (
+    compare_psd,
+    generate_sieve_ground_truth,
+    compute_psd,
+    compute_sieve_analysis,
+    full_psd_analysis,
+)
+
+
+class TestComparePsd(unittest.TestCase):
+    """Tests for compare_psd()."""
+
+    def test_identical_curves_zero_error(self):
+        """Comparing identical curves should yield RMSE ~ 0 and KS ~ 0."""
+        sizes = np.linspace(1, 100, 50).tolist()
+        passing = np.linspace(0, 100, 50).tolist()
+        result = compare_psd(sizes, passing, sizes, passing)
+        self.assertAlmostEqual(result['rmse'], 0.0, places=2)
+        self.assertAlmostEqual(result['ks_statistic'], 0.0, places=2)
+        self.assertAlmostEqual(result['d50_relative_error'], 0.0, places=2)
+
+    def test_known_offset(self):
+        """A uniform offset in passing should produce predictable RMSE."""
+        sizes = np.linspace(1, 100, 50).tolist()
+        passing_a = np.linspace(0, 100, 50).tolist()
+        passing_b = np.linspace(10, 100, 50).tolist()  # shifted
+        result = compare_psd(sizes, passing_a, sizes, passing_b)
+        self.assertGreater(result['rmse'], 0.0)
+        self.assertGreater(result['ks_statistic'], 0.0)
+
+    def test_d50_values_present(self):
+        """Result should contain estimated and true D50."""
+        sizes = np.linspace(1, 50, 30).tolist()
+        passing = np.linspace(0, 100, 30).tolist()
+        result = compare_psd(sizes, passing, sizes, passing)
+        self.assertIn('estimated_d50', result)
+        self.assertIn('true_d50', result)
+        self.assertIn('d50_relative_error', result)
+
+    def test_different_size_grids(self):
+        """Curves on different size grids should still compare correctly."""
+        est_sizes = np.linspace(1, 80, 40).tolist()
+        est_passing = np.linspace(0, 100, 40).tolist()
+        true_sizes = np.linspace(5, 60, 20).tolist()
+        true_passing = np.linspace(0, 100, 20).tolist()
+        result = compare_psd(est_sizes, est_passing, true_sizes, true_passing)
+        self.assertFalse(np.isnan(result['rmse']))
+        self.assertFalse(np.isnan(result['ks_statistic']))
+
+    def test_short_arrays_return_nan(self):
+        """Arrays with < 2 elements should return NaN metrics."""
+        result = compare_psd([1.0], [50.0], [1.0], [50.0])
+        self.assertTrue(np.isnan(result['rmse']))
+
+    def test_metrics_are_positive(self):
+        """RMSE and KS should be non-negative."""
+        rng = np.random.default_rng(42)
+        d_est = rng.lognormal(2.5, 0.4, 80)
+        d_true = rng.lognormal(2.6, 0.3, 100)
+        s1, p1 = compute_psd(d_est.tolist())
+        s2, p2 = compute_psd(d_true.tolist())
+        result = compare_psd(s1.tolist(), p1.tolist(), s2.tolist(), p2.tolist())
+        self.assertGreaterEqual(result['rmse'], 0.0)
+        self.assertGreaterEqual(result['ks_statistic'], 0.0)
+        self.assertGreaterEqual(result['d50_relative_error'], 0.0)
+
+
+class TestGenerateSieveGroundTruth(unittest.TestCase):
+    """Tests for generate_sieve_ground_truth()."""
+
+    def setUp(self):
+        rng = np.random.default_rng(42)
+        self.diameters = rng.lognormal(mean=2.5, sigma=0.4, size=100).tolist()
+
+    def test_output_keys(self):
+        """Should return sieve_sizes, cum_passing, retained."""
+        result = generate_sieve_ground_truth(self.diameters)
+        self.assertIn('sieve_sizes', result)
+        self.assertIn('cum_passing', result)
+        self.assertIn('retained', result)
+
+    def test_output_lengths_match(self):
+        """All output arrays should have the same length."""
+        result = generate_sieve_ground_truth(self.diameters)
+        n = len(result['sieve_sizes'])
+        self.assertEqual(len(result['cum_passing']), n)
+        self.assertEqual(len(result['retained']), n)
+
+    def test_cum_passing_monotonic(self):
+        """Cumulative passing should be non-decreasing."""
+        result = generate_sieve_ground_truth(self.diameters)
+        cp = np.array(result['cum_passing'])
+        if len(cp) > 1:
+            self.assertTrue(np.all(np.diff(cp) >= -1e-10))
+
+    def test_custom_sieve_sizes(self):
+        """Custom sieve sizes should be used."""
+        custom = [5.0, 10.0, 20.0, 50.0]
+        result = generate_sieve_ground_truth(self.diameters, sieve_sizes=custom)
+        self.assertEqual(len(result['sieve_sizes']), len(custom))
+
+    def test_round_trip_consistency(self):
+        """Ground truth sieve from known diameters should be consistent
+        with compute_sieve_analysis."""
+        gt = generate_sieve_ground_truth(self.diameters)
+        sv_sizes, _, sv_passing = compute_sieve_analysis(self.diameters)
+        np.testing.assert_array_almost_equal(
+            gt['cum_passing'], sv_passing.tolist(), decimal=4,
+        )
+
+
+class TestEndToEndComparison(unittest.TestCase):
+    """Integration test: generate, estimate PSD, compare with ground truth."""
+
+    def test_full_comparison_pipeline(self):
+        """Full pipeline: generate diameters, compute PSD, compare."""
+        rng = np.random.default_rng(99)
+        true_d = rng.lognormal(2.5, 0.3, 100).tolist()
+
+        # Estimated PSD (simulate some noise)
+        est_d = [d * (1 + rng.normal(0, 0.05)) for d in true_d]
+
+        est_psd = full_psd_analysis(est_d)
+        true_gt = generate_sieve_ground_truth(true_d)
+
+        result = compare_psd(
+            est_psd['sizes'], est_psd['passing'],
+            true_gt['sieve_sizes'], true_gt['cum_passing'],
+        )
+        # With only 5% noise, RMSE should be moderate
+        self.assertLess(result['rmse'], 30.0)
+        self.assertLess(result['d50_relative_error'], 0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Pixel-to-mm calibration (reference object or direct pixel size)
- PSD comparison: RMSE, KS statistic, D50 relative error
- Sieve data import + dashed red overlay on PSD chart
- 22 new tests (10 calibration + 12 PSD comparison)

@codex Die Kalibrierung verwendet zwei Punkte und eine bekannte Länge. Aber bei einer schrägen Kamera verzerrt die Perspektive die Pixel-Größe über das Bild. Sollte ich eine vollständige Homographie-Kalibrierung implementieren statt eines einzigen pixel_size_mm? 🇩🇪📐

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)