### PR TITLE
Feat: Add /api/health + /api/version endpoints and refresh architecture data-flow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,3 +4,5 @@ GrainSight -- 3D Particle Size & Granulometry Analyzer.
 A FastAPI web application for grain size estimation from RGB-D data
 using marker-based watershed segmentation and Rosin-Rammler PSD fitting.
 """
+
+__version__ = "2.0.0"

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
+from . import __version__
 from .simulation.grain_generator import generate_grain_bed
 from .simulation.segmentation import (
     segment_grains_watershed,
@@ -62,7 +63,7 @@ import numpy as np
 app = FastAPI(
     title="GrainSight",
     description="3D Particle Size & Granulometry Analyzer",
-    version="2.0.0",
+    version=__version__,
 )
 
 static_dir = Path(__file__).parent / "static"
@@ -279,6 +280,34 @@ async def _broadcast(msg: dict):
 async def root():
     """Serve the single-page application."""
     return FileResponse(str(static_dir / "index.html"))
+
+
+# ------------------------------------------------------------------ #
+# System endpoints (liveness / version probes)
+# ------------------------------------------------------------------ #
+
+@app.get("/api/health", tags=["System"])
+async def api_health():
+    """Lightweight liveness probe for load balancers and deployment tooling.
+
+    Returns the app version and whether a simulated scene is currently loaded
+    in the in-memory state.
+    """
+    return {
+        "status": "ok",
+        "version": __version__,
+        "sim_initialized": state["rgb"] is not None,
+    }
+
+
+@app.get("/api/version", tags=["System"])
+async def api_version():
+    """Return the current GrainSight package version.
+
+    Sourced from ``app.__version__`` so the HTTP surface, the FastAPI metadata,
+    and the README badge all stay in lockstep.
+    """
+    return {"version": __version__}
 
 
 @app.post("/api/generate")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,18 @@ Browser (SPA)                 FastAPI Server (port 8010)
 1. **Generation**: `grain_generator.py` creates synthetic RGB-D images with
    ground-truth labels and known grain diameters.
 
-2. **Segmentation**: `segmentation.py` processes the depth map through
-   the watershed pipeline to produce a label image.
+2. **Segmentation**: `segmentation.py` produces a label image from the depth
+   map (and optionally the RGB image). The active algorithm is selected by
+   `settings.segmentation_method` and dispatched in `main.py::_run_segmentation`:
+
+   | `segmentation_method` | Function | Inputs | Notes |
+   |-----------------------|----------|--------|-------|
+   | `watershed` (default) | `segment_grains_watershed` | depth + optional RGB | Marker-based watershed over smoothed depth with peak-local-max seeds (`smooth_sigma`, `min_distance`, `peak_threshold_rel`). |
+   | `depth_edges` | `segment_grains_depth_edges` | depth | Gradient-threshold pipeline (`depth_edge_threshold`); faster, no RGB. |
+   | `rgbd` | `segment_grains_rgbd` | depth + RGB | Fuses depth and color gradients with a convex combination `depth_weight + color_weight = 1`. Robust against flat-depth but colored grains. |
+
+   See [`docs/segmentation_theory.md`](segmentation_theory.md) for the
+   mathematical treatment of each method and a comparison of failure modes.
 
 3. **Measurement**: `grain_measurement.py` computes geometric properties
    (area, diameter, axes, circularity, volume) for each labelled grain.

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,52 @@
+"""Tests for the /api/health and /api/version system endpoints.
+
+These endpoints are used by deployment tooling (nginx / systemd / cPanel
+Passenger) for liveness probes and to verify that the deployed build matches
+the expected commit. The version is sourced from ``app.__version__`` so the
+HTTP surface and the package metadata stay in sync.
+"""
+
+from fastapi.testclient import TestClient
+
+from app import __version__
+from app.main import app, state
+
+
+client = TestClient(app)
+
+
+class TestHealthEndpoint:
+    """Coverage for GET /api/health."""
+
+    def test_health_returns_200(self):
+        response = client.get("/api/health")
+        assert response.status_code == 200
+
+    def test_health_payload_shape(self):
+        payload = client.get("/api/health").json()
+        assert set(payload.keys()) == {"status", "version", "sim_initialized"}
+        assert payload["status"] == "ok"
+        assert payload["version"] == __version__
+        assert isinstance(payload["sim_initialized"], bool)
+
+    def test_health_reflects_sim_state(self):
+        # Baseline: no scene loaded => sim_initialized is False.
+        original_rgb = state["rgb"]
+        state["rgb"] = None
+        try:
+            payload = client.get("/api/health").json()
+            assert payload["sim_initialized"] is False
+        finally:
+            state["rgb"] = original_rgb
+
+
+class TestVersionEndpoint:
+    """Coverage for GET /api/version."""
+
+    def test_version_returns_200(self):
+        response = client.get("/api/version")
+        assert response.status_code == 200
+
+    def test_version_payload_matches_package(self):
+        payload = client.get("/api/version").json()
+        assert payload == {"version": __version__}


### PR DESCRIPTION
## Summary

- **Deployment probes** — new `GET /api/health` (returns `status`, `version`, `sim_initialized`) and `GET /api/version` sourced from a single `app.__version__` constant. Both routes sit under a Swagger `System` tag so they group separately from the main GrainSight API.
- **Version single-source-of-truth** — `FastAPI(version=...)` and the HTTP surface now both read from `app.__version__`, eliminating drift between the OpenAPI metadata and the runtime endpoints.
- **Architecture doc refresh** — `docs/architecture.md` Data Flow step 2 now enumerates the three active segmentation methods (watershed, depth_edges, rgbd) with their inputs, selector keys, and the RGB-D convex-combination weights, and cross-links `docs/segmentation_theory.md`.

## Test plan

- `pytest -q` → **57/57 passed** (52 baseline + 5 new in `tests/test_health.py`)
- Direct runtime probe via `TestClient`:
  - `GET /api/health` → `200 {'status': 'ok', 'version': '2.0.0', 'sim_initialized': False}`
  - `GET /api/version` → `200 {'version': '2.0.0'}`
- Verified `app.__version__ == app.version == '2.0.0'` (FastAPI metadata now sourced from the package constant).
- Architecture diagram (ASCII block) still renders unchanged; new table renders in GitHub preview.

## Notes

- Routes added directly to `main.py` where all existing endpoints live. A `routes.py` refactor is a separate, larger scope and not part of this PR.
- `sim_initialized` is derived from `state['rgb'] is not None` — the cheapest, dependency-free signal of "a scene has been generated this session". Intentionally does not check `labels` so the probe stays truthful even during a mid-pipeline reload.

Closes #22
Closes #23